### PR TITLE
API: Change main_lincls --batch-size argument to match main_moco

### DIFF
--- a/main_lincls.py
+++ b/main_lincls.py
@@ -53,7 +53,7 @@ parser.add_argument('--start-epoch', default=0, type=int, metavar='N',
 parser.add_argument('-b', '--batch-size', default=1024, type=int,
                     metavar='N',
                     help='mini-batch size (default: 1024), this is the total '
-                         'batch size of all GPUs on the current node when '
+                         'batch size of all GPUs on all nodes when '
                          'using Data Parallel or Distributed Data Parallel')
 parser.add_argument('--lr', '--learning-rate', default=0.1, type=float,
                     metavar='LR', help='initial (base) learning rate', dest='lr')
@@ -207,7 +207,7 @@ def main_worker(gpu, ngpus_per_node, args):
             # When using a single GPU per process and per
             # DistributedDataParallel, we need to divide the batch size
             # ourselves based on the total number of GPUs we have
-            args.batch_size = int(args.batch_size / ngpus_per_node)
+            args.batch_size = int(args.batch_size / args.world_size)
             args.workers = int((args.workers + ngpus_per_node - 1) / ngpus_per_node)
             model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[args.gpu])
         else:

--- a/main_moco.py
+++ b/main_moco.py
@@ -60,7 +60,7 @@ parser.add_argument('--start-epoch', default=0, type=int, metavar='N',
 parser.add_argument('-b', '--batch-size', default=4096, type=int,
                     metavar='N',
                     help='mini-batch size (default: 4096), this is the total '
-                         'batch size of all GPUs on the current node when '
+                         'batch size of all GPUs on all nodes when '
                          'using Data Parallel or Distributed Data Parallel')
 parser.add_argument('--lr', '--learning-rate', default=0.6, type=float,
                     metavar='LR', help='initial (base) learning rate', dest='lr')


### PR DESCRIPTION
The `--batch-size` argument in `main_moco.py` is the total batch size across all nodes (as specified in the [README](https://github.com/facebookresearch/moco-v3#notes)). However, the argparser documentation mistakenly said the batch size for one node. This argparser description is fixed in this PR to bring it in line with the actual behaviour and the README.

The handling of `--batch-size` in `main_lincls.py` was inconsistent with that of `main_moco.py`, and was still handled as if it were the total batch size per node, not over all nodes (as per the previous behaviour from the moco/simsiam repos). In this PR, we updated it to be consistent with `main_moco.py`, specifying the total batch size over all GPUs on all nodes. The default behaviour remains consistent with the instructions from the [README](https://github.com/facebookresearch/moco-v3#usage-linear-classification), which say to use a total batch size of 1024. (The README specifies 8 GPUs on a single node, but now the behaviour will also be correct with 2 nodes with 4 GPUs each, etc.)